### PR TITLE
Fix empty expenditure error handling

### DIFF
--- a/src/main/java/seedu/address/logic/commands/budget/FindExpenditureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/FindExpenditureCommand.java
@@ -39,7 +39,7 @@ public class FindExpenditureCommand extends Command {
         requireNonNull(model);
         String searchTerm = name.value;
         try {
-            model.updateFilteredRenderableList(renderable -> renderable.contains(searchTerm));
+            model.findRenderable(renderable -> renderable.contains(searchTerm));
         } catch (CommandException e) {
             return new CommandResult(e.getMessage());
         }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -106,4 +106,11 @@ public interface Model {
     void updateFilteredRenderableList(Predicate<Renderable> predicate) throws CommandException;
 
     void repopulateObservableList() throws CommandException;
+
+    /**
+     * Finds renderables within the filtered list based on the predicate given.
+     * @param predicate used by the {@code filtered list} to display select renderables.
+     * @throws CommandException If an error occurs during command execution.
+     */
+    void findRenderable(Predicate<Renderable> predicate) throws CommandException;
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -254,9 +254,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredRenderableList(Predicate<Renderable> predicate) throws CommandException {
+    public void updateFilteredRenderableList(Predicate<Renderable> predicate) {
         requireNonNull(predicate);
         filteredRenderables.setPredicate(predicate);
+    }
+
+    @Override
+    public void findRenderable(Predicate<Renderable> predicate) throws CommandException {
+        updateFilteredRenderableList(predicate);
         if (filteredRenderables.size() == 0) {
             throw new CommandException(MESSAGE_NO_ENTRIES_FOUND);
         }


### PR DESCRIPTION
updateFilteredRenderableList method in ModelManager no longer throws a CommandException if the filtered list is empty this has been extracted out to the findRenderable method instead.